### PR TITLE
Fix newline characters and punctuation

### DIFF
--- a/Cornelica/scenario/006.txt
+++ b/Cornelica/scenario/006.txt
@@ -212,7 +212,7 @@
 [Lily]"Er... SQs have a different magical power than the world\n you were in, Al, they're packed with this world's\nmagical power, though..."
 
 @bs f=リリィ@蔑み x=350 y=50 t=200
-[Lily]"... I'm sorry. I don't know you got here either, Al."
+[Lily]"... I'm sorry. I don't know how you got here either, Al."
 
 ;;主人公うなずく
 @bs f=アル@焦り op=焦り x=-350 y=50 t=200

--- a/Cornelica/scenario/027.txt
+++ b/Cornelica/scenario/027.txt
@@ -214,7 +214,7 @@
 
 @bs f=リリィ@哀しみ op=困惑  x=350 y=50 t=200 wt=1
 
-[Lily]"Argh...it's look hard, but it can't be helped...uhm"
+[Lily]"Argh...it looks hard, but it can't be helped...uhm"
 
 @huki b=8
 @bs f=アル@笑顔 op=焦り x=-350 y=50 t=400 wt=1

--- a/Cornelica/scenario/029.txt
+++ b/Cornelica/scenario/029.txt
@@ -60,7 +60,7 @@
 
 @bs f=ヴェルナ@微笑 x=350 y=50 t=200 wt=1
 
-[Verna]"You can do it. Here, Al: try this"
+[Verna]"You can do it. Here, Al, try this"
 
 @bs f=アル@笑顔 x=-350 y=50 t=200 wt=1
 @move f=アル@笑顔 x=-350 y=100 w=100 h=100 t=160 wt=1

--- a/Cornelica/scenario/030.txt
+++ b/Cornelica/scenario/030.txt
@@ -58,7 +58,7 @@
 
 @bs f=ヴェルナ@微笑 x=350 y=50 t=200 wt=1
 
-[Verna]"Well, you can do it. So, Al: try this"
+[Verna]"Well, you can do it. So, Al, try this"
 
 @bs f=アル@笑顔 x=-350 y=50 t=200 wt=1
 @move f=アル@笑顔 x=-350 y=100 w=100 h=100 t=160 wt=1

--- a/Cornelica/scenario/039.txt
+++ b/Cornelica/scenario/039.txt
@@ -344,7 +344,7 @@
 
 @bs f=ヴァネッサ@微笑 x=300 y=50 t=200 wt=1
 
-[？？？]"...oh well. If you do not feel like talking, I'll return to my room"
+[？？？]"...oh well. If you do not feel like talking, I'll return to my\nroom"
 
 @bgm
 @move f=ヴァネッサ@普通 x=350 y=50 w=100 h=100 opa=0 t=400 wt=0

--- a/Cornelica/scenario/042.txt
+++ b/Cornelica/scenario/042.txt
@@ -125,7 +125,7 @@
 
 @bs f=白良@微笑 x=350 y=50 t=400
 
-[？？？]"I see... stealing the Lord \C[2]Philosopher's Stone\[0]..."
+[？？？]"I see... stealing the Lord \C[2]Philosopher's Stone\C[0]..."
 
 ;;主人公：驚き
 @bs f=アル@驚き op=ビックリ x=-350 y=50 t=200 wt=1
@@ -169,7 +169,7 @@
 @bs f=アル@焦り x=-350 y=50 t=200 wt=1
 @bs f=白良@微笑 x=350 y=50 t=200 wt=1
 
-[Shirao]"I did not introduce myself yet. My name is Shirao... I'm the one who is serving as the guru of this love group"
+[Shirao]"I did not introduce myself yet. My name is Shirao...\nI'm the one who is serving as the guru of this love group"
 
 @bs f=アル@屈辱 x=-350 y=50 t=200 wt=1
 @move f=アル@屈辱 x=-350 y=100 w=100 h=100 t=160 wt=1
@@ -270,7 +270,7 @@
 
 @bs f=白良@笑み x=350 y=50 t=400 wt=1
 
-[Shirao]"Please don't have such a face. \nBecause I'm not bad... fufu, Al-kun, you are a very kind person"
+[Shirao]"Please don't have such a face. \nBecause I'm not bad... fufu, Al-kun, you are a very kind\nperson"
 
 @bs f=白良@通常 x=350 y=50 t=400 wt=1
 

--- a/Cornelica/scenario/043.txt
+++ b/Cornelica/scenario/043.txt
@@ -126,7 +126,7 @@
 @bs f=アル@困り x=-350 y=50 t=300 wt=1
 @bs f=白良@微笑 x=350 y=50 t=300 wt=1
 
-[Shirao]"The Lord said 'If you capture a human with the same age as Lily, hand him over'"
+[Shirao]"The Lord said 'If you capture a human with the same age as\nLily, hand him over'"
 
 @bs f=白良@通常 x=350 y=50 t=300 wt=1
 

--- a/Cornelica/scenario/cut003c.txt
+++ b/Cornelica/scenario/cut003c.txt
@@ -25,9 +25,9 @@
 
 [Succubus student]"...gradually the force came out, the expression is loose too"
 
-[Succubus student]"I am still a top-ranking maker, the tits fuck is the hardest thing"
+[Succubus student]"I am still a top-ranking maker, the tits fuck is the hardest\nthing"
 
-[Succubus student]"Now, please pull out more power. Breathe slowly, sense only my breasts and your dick"
+[Succubus student]"Now, please pull out more power. Breathe slowly, sense only\nmy breasts and your dick"
 
 [Succubus student]"The tip of your dick is swalling. Although it's a little \nearly, please take it out in my breasts"
 

--- a/Cornelica/scenario/cut004d.txt
+++ b/Cornelica/scenario/cut004d.txt
@@ -7,14 +7,14 @@
 
 [Succubus student]"All right, Just saying you are bad because it's a random ......"
 ;;Need Review - 「せんせぇがね、あなたはらんぼうだからダメだって言うんだけどぉ……」
-[Succubus student]"... but, there are also people who will love to do this like this"
+[Succubus student]"... but, there are also people who will love to do this like\nthis"
 
 [Succubus student]"Hey Onii-chan. Do you not dislike it? You came again ♪"
 ;;Need Review - 「ねぇおにいちゃん。おにいちゃんは、らんぼうにHなことされるのきらい？　きらいなわけないよね？　またきてくれたもんねぇ♪」
 
 @se f=愛液1 pitch=80
 
-[Succubus student]"Therefore, if Onii-chan ejaculates like this, I'd rather like Onii-chan"
+[Succubus student]"Therefore, if Onii-chan ejaculates like this, I'd rather like\nOnii-chan"
 ;;Need Review - 「だからね。おにいちゃんがこのまま射精してくれたら、わたしおにいちゃんのことがもっと好きになっちゃうかも」
 
 [Succubus student]"And if you become my pet, \nI will bully more than I do now ♪"

--- a/Cornelica/scenario/rp02a.txt
+++ b/Cornelica/scenario/rp02a.txt
@@ -140,7 +140,7 @@
 @se f=パイズリ・手コキ２ pitch=50
 @qk
 
-　Because it's so embarrassing to ejaculate while being watched\nby a crowd, I don't want to.\nBut, that feeling alone couldn't hold back my orgasm――
+　Because it's so embarrassing to ejaculate while being\nwatchedby a crowd, I don't want to.\nBut, that feeling alone couldn't hold back my orgasm――
 
 ;;SE射精音
 ;;射精エフェクト

--- a/Cornelica/scenario/rp06b.txt
+++ b/Cornelica/scenario/rp06b.txt
@@ -142,7 +142,7 @@
 @flash t=500 wt=0
 @bgv f=パイズリ・手コキ２ pitch=80
 
-[Arne/arn0050]"Ahaha! ... Your body's shuddering all over! How's it?\sIf 's this, you can't even afford to faint, right?"
+[Arne/arn0050]"Ahaha! ... Your body's shuddering all over! How's it?\nIf 's this, you can't even afford to faint, right?"
 
 @se f=愛液1 pitch=50
 

--- a/Cornelica/scenario/rp10a.txt
+++ b/Cornelica/scenario/rp10a.txt
@@ -138,7 +138,7 @@
 @flash t=300 wt=0
 @bgv f=パイズリ・手コキ１ pitch=110
 
-　My penis is sucked intensely by the machine the Vlasta holds.
+　My penis is sucked intensely by the machine the Vlasta\nholds.
 
 [Vlasta B/bbt0014]"Beginning dick suction.\nWhile folds inside the vaccum entrance squeeze, sucking on\nthe glans. Sucking out semen to the last drop."
 


### PR DESCRIPTION
Through my first playthrough of the game I used your translation and fixed some very noticeable mistakes like misplaced newline characters.

This patch adds:
- added/moved newline characters to fit the dialogue box length
- a few punctuation fixes ("Al: try this" -> "Al, try this")
- a few grammar fixes ("it's look hard" -> "it looks hard")

I went through almost every scenes (except 2) and modified the files accordingly most of the time.
I still overlooked some of them but I think it fixes more than half of the misplaced newlines and thus brings this translation closer to completion.